### PR TITLE
rootdir: Update cpufreq permissions when governor changes

### DIFF
--- a/rootdir/ueventd.rc
+++ b/rootdir/ueventd.rc
@@ -98,3 +98,43 @@ subsystem adf
 
 # DVB API device nodes
 /dev/dvb*                 0660   root       system
+
+# Governor permissions
+/sys/devices/system/cpu/cpu*   cpufreq/scaling_governor   0664  system system
+
+/sys/devices/system/cpu/cpufreq ondemand/boostfreq   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/boostpulse  0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/boosttime   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/down_differential   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/down_differential_multi_core   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/ignore_nice_load   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/input_boost   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/io_is_busy      0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/optimal_freq   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/powersave_bias  0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/sampling_down_factor    0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/sampling_rate   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/sampling_rate_min   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/sync_freq   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/up_threshold   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/up_threshold_any_cpu_load   0664    system  system
+/sys/devices/system/cpu/cpufreq ondemand/up_threshold_multi_core   0664    system  system
+
+/sys/devices/system/cpu/cpufreq interactive/above_hispeed_delay 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/align_windows 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/boost  0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/boostpulse  0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/boostpulse_duration  0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/go_hispeed_load 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/hispeed_freq    0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/io_is_busy      0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/max_freq_hysteresis 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/min_sample_rate 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/min_sample_time 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/sampling_down_factor 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/sync_freq 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/target_loads 0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/timer_rate  0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/timer_slack      0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/up_threshold_any_cpu_freq      0664    system  system
+/sys/devices/system/cpu/cpufreq interactive/up_threshold_any_cpu_load      0664    system  system


### PR DESCRIPTION
- Requires a kernel change to send the uevent.
- This should alleviate some frustration that the performance/kernel
  folks have expressed regarding the Power HAL.

Change-Id: I31e6e13534159214a3b600082b7c0e4249433364

rootdir: Tighten permissions on boostpulse nodes
- New PowerHAL code will only write to this as the system user, so
  remove the need for it to be world writable.

Change-Id: Ia9e69a6feff7c5ef1ff34a1180225e4008e8130f

rootdir: Set perms on interactive governor's min_sample_time

Change-Id: I75e9f424af731bdf1ca222eee2f4f18b20a6552b

rootdir: set perms on ondemand governor's up_threshold

Change-Id: I0a042a81be677821fa4099a3e19281d390dd27c3

Set permissions on io_is_busy node for interactive governor

Change-Id: I9dce40b0680fdb594f415aade22dbd92ebffa43c

rootdir: Set permissions for additional ondemand sysfs nodes

Change-Id: Id39cab7ab69ea8f67de99f5b4ee342e2c52ebedd

ueventd: Add rules for governors and cpufreq

This change requires a kernel patch in cpufreq to work.

Change-Id: I6281645291ca4516748f65d0799e14971c5fb2ea

rootdir: Remove duplicate rule

Change-Id: I1e7d06daa1d2092d9522a6a49842eb479da267fd
